### PR TITLE
feat(stats): add privacy stats country aggregation with geolite cache

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -15,3 +15,10 @@ counter:
 
   # Path to the SQLite database file
   dbPath: "data/visitors.db"
+
+stats:
+  # Enable/disable country stats on the privacy page
+  enabled: false
+
+  # Path to the GeoLite country database file
+  geoLiteDbPath: "data/GeoLite2-Country.mmdb"

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/ssh v0.0.0-20250128164007-98fd5ae11894
 	github.com/charmbracelet/wish v1.4.7
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/mmcdole/gofeed v1.2.1
 	github.com/muesli/termenv v0.16.0
+	github.com/oschwald/geoip2-golang v1.11.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.29.0
 )
@@ -21,7 +23,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/keygen v0.5.3 // indirect
 	github.com/charmbracelet/log v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/conpty v0.1.0 // indirect
 	github.com/charmbracelet/x/errors v0.0.0-20240508181413-e8d8b6e2de86 // indirect
@@ -46,6 +47,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
+	github.com/oschwald/maxminddb-golang v1.13.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,10 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/oschwald/geoip2-golang v1.11.0 h1:hNENhCn1Uyzhf9PTmquXENiWS6AlxAEnBII6r8krA3w=
+github.com/oschwald/geoip2-golang v1.11.0/go.mod h1:P9zG+54KPEFOliZ29i7SeYZ/GM6tfEL+rgSn03hYuUo=
+github.com/oschwald/maxminddb-golang v1.13.0 h1:R8xBorY71s84yO06NgTmQvqvTvlS/bnYZrrWX1MElnU=
+github.com/oschwald/maxminddb-golang v1.13.0/go.mod h1:BU0z8BfFVhi1LQaonTwwGQlsHUEu9pWNdMfmq4ztm0o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/main.go
+++ b/main.go
@@ -96,7 +96,14 @@ func main() {
 				log.Printf("Failed to update counter: %v", err)
 			}
 		}
-		return ui.NewModelWithCounter(counterStore, visitorCount, remoteIP, trackingEnabled), []tea.ProgramOption{tea.WithAltScreen()}
+		return ui.NewModelWithCounter(
+			counterStore,
+			visitorCount,
+			remoteIP,
+			trackingEnabled,
+			cfg.Stats.Enabled,
+			cfg.Stats.GeoLiteDBPath,
+		), []tea.ProgramOption{tea.WithAltScreen()}
 	}
 
 	s, err := wish.NewServer(

--- a/pages/model.go
+++ b/pages/model.go
@@ -255,7 +255,7 @@ func (m model) View() string {
 	case contactPage:
 		content = RenderContact(m.styles, themeLabel)
 	case privacyPage:
-		content = RenderPrivacy(m.styles, 0, false, false, themeLabel)
+		content = RenderPrivacy(m.styles, 0, false, false, themeLabel, false, 0, "", 0, "")
 	case feedPage:
 		content = RenderFeed(m.styles, nil, 0, 0, 0, false, "", themeLabel)
 	}

--- a/pages/privacy.go
+++ b/pages/privacy.go
@@ -15,7 +15,18 @@ const (
 	privacyRightWidth = 40
 )
 
-func RenderPrivacy(styles view.ThemeStyles, cursor int, trackingEnabled bool, trackingAvailable bool, themeLabel string) string {
+func RenderPrivacy(
+	styles view.ThemeStyles,
+	cursor int,
+	trackingEnabled bool,
+	trackingAvailable bool,
+	themeLabel string,
+	statsEnabled bool,
+	statsTotal int,
+	statsTopCountry string,
+	statsTopCount int,
+	statsError string,
+) string {
 	var b strings.Builder
 
 	b.WriteString(styles.Title.Render("━━━ Privacy ━━━"))
@@ -28,54 +39,69 @@ func RenderPrivacy(styles view.ThemeStyles, cursor int, trackingEnabled bool, tr
 
 	if !trackingAvailable {
 		b.WriteString(styles.Content.Render("Tracking is disabled on this server."))
+	} else {
+		options := []struct {
+			label string
+			desc  string
+		}{
+			{label: "Yes", desc: "Allow visit tracking"},
+			{label: "No", desc: "Do not track"},
+		}
+
+		b.WriteString(styles.Content.Render("Choose whether your IP is tracked."))
+		b.WriteString("\n\n")
+
+		for i, opt := range options {
+			cursorMark := "  "
+			if cursor == i {
+				cursorMark = "→ "
+			}
+			leftText := cursorMark + opt.label
+			leftCell := lipgloss.NewStyle().Width(privacyLeftWidth).Render(leftText)
+			if cursor == i {
+				leftCell = styles.Selected.Render(leftCell)
+			} else {
+				leftCell = styles.Menu.Render(leftCell)
+			}
+
+			rightCell := lipgloss.NewStyle().
+				Width(privacyRightWidth).
+				Align(lipgloss.Right).
+				Render(opt.desc)
+			if cursor == i {
+				rightCell = styles.Selected.Copy().Bold(false).Faint(true).Render(rightCell)
+			} else {
+				rightCell = styles.Subtle.Render(rightCell)
+			}
+
+			b.WriteString(leftCell + rightCell)
+			b.WriteString("\n")
+		}
+
+		status := "No"
+		if trackingEnabled {
+			status = "Yes"
+		}
+		b.WriteString(styles.Subtle.Render(fmt.Sprintf("Current: %s", status)))
+	}
+
+	if statsEnabled {
+		b.WriteString("\n\n")
+		b.WriteString(styles.Accent.Render("━━━ Stats ━━━"))
 		b.WriteString("\n")
-		b.WriteString(styles.Help.Render(themeLabel + " • esc: back to menu"))
-		return b.String()
-	}
 
-	options := []struct {
-		label string
-		desc  string
-	}{
-		{label: "Yes", desc: "Allow visit tracking"},
-		{label: "No", desc: "Do not track"},
-	}
-
-	b.WriteString(styles.Content.Render("Choose whether your IP is tracked."))
-	b.WriteString("\n\n")
-
-	for i, opt := range options {
-		cursorMark := "  "
-		if cursor == i {
-			cursorMark = "→ "
-		}
-		leftText := cursorMark + opt.label
-		leftCell := lipgloss.NewStyle().Width(privacyLeftWidth).Render(leftText)
-		if cursor == i {
-			leftCell = styles.Selected.Render(leftCell)
+		if statsError != "" {
+			b.WriteString(styles.Subtle.Render("Unavailable: " + statsError))
 		} else {
-			leftCell = styles.Menu.Render(leftCell)
+			topCountry := statsTopCountry
+			if strings.TrimSpace(topCountry) == "" {
+				topCountry = "N/A"
+			}
+			b.WriteString(styles.Content.Render(fmt.Sprintf("Total unique visitors: %d", statsTotal)))
+			b.WriteString("\n")
+			b.WriteString(styles.Content.Render(fmt.Sprintf("Top country: %s (%d)", topCountry, statsTopCount)))
 		}
-
-		rightCell := lipgloss.NewStyle().
-			Width(privacyRightWidth).
-			Align(lipgloss.Right).
-			Render(opt.desc)
-		if cursor == i {
-			rightCell = styles.Selected.Copy().Bold(false).Faint(true).Render(rightCell)
-		} else {
-			rightCell = styles.Subtle.Render(rightCell)
-		}
-
-		b.WriteString(leftCell + rightCell)
-		b.WriteString("\n")
 	}
-
-	status := "No"
-	if trackingEnabled {
-		status = "Yes"
-	}
-	b.WriteString(styles.Subtle.Render(fmt.Sprintf("Current: %s", status)))
 
 	help := "↑/↓: select • enter: confirm • esc/backspace: menu • q: quit • " + themeLabel
 	b.WriteString("\n")

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,10 @@ ssh:
 counter:
   enabled: true
   dbPath: "data/visitors.db"
+
+stats:
+  enabled: false
+  geoLiteDbPath: "data/GeoLite2-Country.mmdb"
 ```
 
 The `counter` section supports either:
@@ -134,6 +138,8 @@ These variables override file values:
 - Visitor count tracks unique IPs in SQLite.
 - Opted-out IPs are stored in a dedicated table and removed from counted visitors.
 - If tracking is disabled, the app still displays the current count without recording new visits.
+- Optional `stats` block can show privacy-page stats when enabled.
+- Country stats read from `stats.geoLiteDbPath` and report top country by unique visitors.
 
 ## 5: Container and deployment
 ### 5.1: Docker image flow
@@ -165,7 +171,7 @@ entrypoint.sh container startup and host key bootstrap
 Version constants are defined in `version/version.go`.
 At this snapshot:
 - App name: `termfolio`
-- Version: `0.1.5`
+- Version: `0.1.6`
 
 Print version:
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 const (
 	Major = 0
 	Minor = 1
-	Patch = 5
+	Patch = 6
 
 	AppName = "termfolio"
 	AppDesc = "SSH-based interactive portfolio application served over SSH, built with Go, Wish, and Bubble Tea."


### PR DESCRIPTION
feat(stats): add privacy stats country aggregation with geolite cache and safe error handling & support stats scalar config toggles & bump app version for release readiness

- purpose deliver privacy stats that stay visible when enabled & prevent filesystem path leakage while preserving clear geolite db failure feedback
- reason remove startup failures from stats scalar config usage & reduce repeated full visitor scans that increased per session overhead
- update add stats yaml scalar parsing & cache top country calculations with invalidation on visitor changes & bump version to 0 1 6 and refresh docs