### PR TITLE
feat(privacy): add top 5 country stats rendering in privacy view & align stats block with core content column & improve option row placement & bump version to `v0.2.0`

### DIFF
--- a/pages/model.go
+++ b/pages/model.go
@@ -255,7 +255,7 @@ func (m model) View() string {
 	case contactPage:
 		content = RenderContact(m.styles, themeLabel)
 	case privacyPage:
-		content = RenderPrivacy(m.styles, 0, false, false, themeLabel, false, 0, "", 0, "")
+		content = RenderPrivacy(m.styles, 0, false, false, themeLabel, false, 0, nil, "")
 	case feedPage:
 		content = RenderFeed(m.styles, nil, 0, 0, 0, false, "", themeLabel)
 	}

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ These variables override file values:
 - Opted-out IPs are stored in a dedicated table and removed from counted visitors.
 - If tracking is disabled, the app still displays the current count without recording new visits.
 - Optional `stats` block can show privacy-page stats when enabled.
-- Country stats read from `stats.geoLiteDbPath` and report top country by unique visitors.
+- Country stats read from `stats.geoLiteDbPath` and report top 5 countries by unique visitors.
 
 ## 5: Container and deployment
 ### 5.1: Docker image flow
@@ -171,7 +171,7 @@ entrypoint.sh container startup and host key bootstrap
 Version constants are defined in `version/version.go`.
 At this snapshot:
 - App name: `termfolio`
-- Version: `0.1.6`
+- Version: `0.2.0`
 
 Print version:
 

--- a/ui/model.go
+++ b/ui/model.go
@@ -46,6 +46,7 @@ type model struct {
 	statsTotal      int
 	statsTopCountry string
 	statsTopCount   int
+	statsTopList    []counter.CountryCount
 	statsError      string
 	feedItems       []pages.FeedItem
 	feedCursor      int
@@ -81,6 +82,7 @@ func initialModel() model {
 		statsTotal:      0,
 		statsTopCountry: "",
 		statsTopCount:   0,
+		statsTopList:    nil,
 		statsError:      "",
 		feedItems:       nil,
 		feedCursor:      0,
@@ -387,8 +389,7 @@ func (m model) View() string {
 			m.themeLabel(),
 			m.statsEnabled,
 			m.statsTotal,
-			m.statsTopCountry,
-			m.statsTopCount,
+			m.statsTopList,
 			m.statsError,
 		)
 	case feedPage:
@@ -446,6 +447,7 @@ func (m model) refreshStats() model {
 	m.statsTotal = 0
 	m.statsTopCountry = ""
 	m.statsTopCount = 0
+	m.statsTopList = nil
 	m.statsError = ""
 
 	if !m.statsEnabled {
@@ -465,6 +467,7 @@ func (m model) refreshStats() model {
 	m.statsTotal = stats.TotalVisitors
 	m.statsTopCountry = stats.TopCountry
 	m.statsTopCount = stats.TopCountryVisitors
+	m.statsTopList = append([]counter.CountryCount(nil), stats.TopCountries...)
 	return m
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,8 +2,8 @@ package version
 
 const (
 	Major = 0
-	Minor = 1
-	Patch = 6
+	Minor = 2
+	Patch = 0
 
 	AppName = "termfolio"
 	AppDesc = "SSH-based interactive portfolio application served over SSH, built with Go, Wish, and Bubble Tea."


### PR DESCRIPTION
feat(privacy): add top 5 country stats rendering in privacy view & align stats block with core content column & improve option row placement & bump version to `v0.2.0`

- purpose deliver cleaner privacy tui presentation with consistent left alignment for stats lines & expose ranked country insights directly in one compact section
- reason previous layout mixed indentation levels and repeated top country output that reduced scan clarity & product scope now requires a minor release for new behavior
- update add sorted top five country aggregation in counter stats & update renderer and model plumbing for list output & set release metadata to 0 2 0